### PR TITLE
Add `bash` code hints where not found

### DIFF
--- a/docs/development_manual.md
+++ b/docs/development_manual.md
@@ -15,7 +15,7 @@ The following requirements must be installed and executed in order to launch the
 
 To run the tests:
 
-```
+```bash
 npm test
 ```
 
@@ -23,7 +23,7 @@ npm test
 
 In addition, the project is configured to provide source code coverage statistics reached thanks to the tests.
 
-```
+```bash
 npm run test:coverage
 ```
 
@@ -33,6 +33,6 @@ This command will produce an HTML coverage report under *coverage* folder.
 
 [ESLint](https://eslint.org/) is used to check code linting:
 
-```
+```bash
 npn run lint
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # FIWARE IoT Agent for LoRaWAN protocol
 
-[![FIWARE IoT Agents](https://img.shields.io/badge/FIWARE-IoT_Agents-5dc0cf.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAAVCAYAAAC33pUlAAAABHNCSVQICAgIfAhkiAAAA8NJREFUSEuVlUtIFlEUx+eO+j3Uz8wSLLJ3pBiBUljRu1WLCAKXbXpQEUFERSQF0aKVFAUVrSJalNXGgmphFEhQiZEIPQwKLbEUK7VvZrRvbr8zzjfNl4/swplz7rn/8z/33HtmRhn/MWzbXmloHVeG0a+VSmAXorXS+oehVD9+0zDN9mgk8n0sWtYnHo5tT9daH4BsM+THQC8naK02jCZ83/HlKaVSzBey1sm8BP9nnUpdjOfl/Qyzj5ust6cnO5FItJLoJqB6yJ4QuNcjVOohegpihshS4F6S7DTVVlNtFFxzNBa7kcaEwUGcbVnH8xOJD67WG9n1NILuKtOsQG9FngOc+lciic1iQ8uQGhJ1kVAKKXUs60RoQ5km93IfaREvuoFj7PZsy9rGXE9G/NhBsDOJ63Acp1J82eFU7OIVO1OxWGwpSU5hb0GqfMydMHYSdiMVnncNY5Vy3VbwRUEydvEaRxmAOSSqJMlJISTxS9YWTYLcg3B253xsPkc5lXk3XLlwrPLuDPKDqDIutzYaj3eweMkPeCCahO3+fEIF8SfLtg/5oI3Mh0ylKM4YRBaYzuBgPuRnBYD3mmhA1X5Aka8NKl4nNz7BaKTzSgsLCzWbvyo4eK9r15WwLKRAmmCXXDoA1kaG2F4jWFbgkxUnlcrB/xj5iHxFPiBN4JekY4nZ6ccOiQ87hgwhe+TOdogT1nfpgEDTvYAucIwHxBfNyhpGrR+F8x00WD33VCNTOr/Wd+9C51Ben7S0ZJUq3qZJ2OkZz+cL87ZfWuePlwRcHZjeUMxFwTrJZAJfSvyWZc1VgORTY8rBcubetdiOk+CO+jPOcCRTF+oZ0okUIyuQeSNL/lPrulg8flhmJHmE2gBpE9xrJNkwpN4rQIIyujGoELCQz8ggG38iGzjKkXufJ2Klun1iu65bnJub2yut3xbEK3UvsDEInCmvA6YjMeE1bCn8F9JBe1eAnS2JksmkIlEDfi8R46kkEkMWdqOv+AvS9rcp2bvk8OAESvgox7h4aWNMLd32jSMLvuwDAwORSE7Oe3ZRKrFwvYGrPOBJ2nZ20Op/mqKNzgraOTPt6Bnx5citUINIczX/jUw3xGL2+ia8KAvsvp0ePoL5hXkXO5YvQYSFAiqcJX8E/gyX8QUvv8eh9XUq3h7mE9tLJoNKqnhHXmCO+dtJ4ybSkH1jc9XRaHTMz1tATBe2UEkeAdKu/zWIkUbZxD+veLxEQhhUFmbnvOezsJrk+zmqMo6vIL2OXzPvQ8v7dgtpoQnkF/LP8Ruu9zXdJHg4igAAAABJRU5ErkJgggA=)](https://www.fiware.org/developers/catalogue/)
+[![FIWARE IoT Agents](https://nexus.lab.fiware.org/repository/raw/public/badges/chapters/iot-agents.svg)](https://www.fiware.org/developers/catalogue/)
 [![](https://img.shields.io/badge/tag-fiware+iot-orange.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/fiware+iot)
 
 
@@ -40,34 +40,38 @@ As it is explained in [What is LoRaWAN™](https://lora-alliance.org/sites/defau
 ### Cloning the Github repository
 
 - Clone the repository with the following command:
-```
-https://github.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN.git
+
+```bash
+git clone https://github.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN.git
 ```
 - Once the repository is cloned, you have to download the dependencies for the project, and let it ready to the execution. From the root folder of the project execute:
-```
+```bash
 npm install
 ```
 
 - Launch the IoT Agent with the default configuration
-```
+```bash
 node bin/iotagent-lora
 ```
 You can use a custom configuration file:
-```
+```bash
 node bin/iotagent-lora custom_config.js
 ```
 The bootstrap process should finish with:
+
 ```
 info: Loading devices from registry
 info: LoRaWAN IoT Agent started
 ```
 
 - Check that the IoTA is running correctly:
-```
+
+```bash
 curl -v http://localhost:4061/iot/about
 ```
 The result must be similar to:
-```
+
+```json
 {"libVersion":"2.6.0-next","port":4061,"baseRoot":"/"}
 ```
 
@@ -75,7 +79,7 @@ The result must be similar to:
 
 A ready to use Docker image is [provided](https://hub.docker.com/r/ioeari/iotagent-lora/)
 
-```
+```bash
 docker run -p 4061:4061 ioeari/iotagent-lora
 ```
 
@@ -83,7 +87,7 @@ docker run -p 4061:4061 ioeari/iotagent-lora
 
 This project contains an example to deploy the IoTA and all the requirement using docker-compose.
 
-```
+```bash
 docker-compose -f docker/docker-compose.yml up
 ```
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -43,7 +43,7 @@ All of them use a relatively simple device or node reporting the following measu
 
 This option allows provisioning a specific device, describing its attributes and LoRaWAN information. **Thus, using a single Application Server, we can provision devices reporting different types of measurements.**
 
-```
+```bash
 curl localhost:4061/iot/devices -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'fiware-service: smartgondor' --header 'fiware-servicepath: /gardens' -d @- <<EOF
 {
   "devices": [
@@ -67,17 +67,17 @@ curl localhost:4061/iot/devices -s -S --header 'Content-Type: application/json' 
           "object_id": "do4",
           "name": "digital_out_4",
           "type": "Number"
-        },  
+        },
         {
           "object_id": "rh2",
           "name": "relative_humidity_2",
           "type": "Number"
-        }, 
+        },
         {
           "object_id": "t1",
           "name": "temperature_1",
           "type": "Number"
-        }       
+        }
       ],
       "internal_attributes": {
         "lorawan": {
@@ -107,7 +107,7 @@ The IoTa will automatically subscribe to new observation notifications from the 
 
 You can query the corresponding entity in the Context Broker with:
 
-```
+```bash
 curl localhost:1026/v2/entities/LORA-N-003 -s -S -H 'Accept: application/json' --header 'fiware-service: smartgondor' --header 'fiware-servicepath: /gardens' | python -mjson.tool
 ```
 
@@ -115,14 +115,14 @@ curl localhost:1026/v2/entities/LORA-N-003 -s -S -H 'Accept: application/json' -
 
 If a group of devices reports the same observations (i.e., smart meters for a neighborhood or building), the *configuration API* can be used to pre-provision all of them with a single request.**With this approach, all the devices sharing the same configuration must be registered under the same Application Server.**
 
-```
+```bash
 curl localhost:4061/iot/services -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'fiware-service: smartgondor' --header 'fiware-servicepath: /gardens' -d @- <<EOF
 {
 	"services": [
    {
     "entity_type": "LoraDeviceGroup",
     "apikey": "",
-    "resource": "4569343567897875",        
+    "resource": "4569343567897875",
     "attributes": [
       {
         "object_id": "bp0",
@@ -138,17 +138,17 @@ curl localhost:4061/iot/services -s -S --header 'Content-Type: application/json'
         "object_id": "do4",
         "name": "digital_out_4",
         "type": "Number"
-      },  
+      },
       {
         "object_id": "rh2",
         "name": "relative_humidity_2",
         "type": "Number"
-      }, 
+      },
       {
         "object_id": "t1",
         "name": "temperature_1",
         "type": "Number"
-      }       
+      }
     ],
     "internal_attributes": {
         "lorawan": {
@@ -177,7 +177,7 @@ In this case, the IoTA will subscribe to any observation coming from the LoRaWAN
 
 Finally, it is also possible to provide a static configuration for the IoTa. As it happens with the previous alternative, this approach is useful for groups of devices which report the same observations. Again, **all the devices sharing the same _Type_ must be registered under the same Application Server.**
 
-```
+```javascript
 var config = {};
 
 config.iota = {
@@ -224,17 +224,17 @@ config.iota = {
                   "object_id": "do4",
                   "name": "digital_out_4",
                   "type": "Number"
-                },  
+                },
                 {
                   "object_id": "rh2",
                   "name": "relative_humidity_2",
                   "type": "Number"
-                }, 
+                },
                 {
                   "object_id": "t1",
                   "name": "temperature_1",
                   "type": "Number"
-                }       
+                }
             ]
         }
     }


### PR DESCRIPTION
Readthedocs can mis-diagnose code styles sometimes.