### PR TITLE
Feature/add coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ before_install:
  - docker run -d --net host -l mosquitto ansi/mosquitto
  - npm update -q
 
+after_script: 
+  - npm run test:coveralls

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <br>
 [![Documentation badge](https://img.shields.io/readthedocs/fiware-lorawan.svg)](http://fiware-lorawan.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://img.shields.io/travis/Atos-Research-and-Innovation/IoTagent-LoRaWAN.svg?branch=master)](https://travis-ci.org/Atos-Research-and-Innovation/IoTagent-LoRaWAN/branches)
+[![Coverage Status](https://coveralls.io/repos/github/Atos-Research-and-Innovation/IoTagent-LoRaWAN/badge.svg?branch=master)](https://coveralls.io/github/Atos-Research-and-Innovation/IoTagent-LoRaWAN?branch=master)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/iot-lorawan.svg)
 
 The Internet of Things Agent for LoRaWAN protocol enables data and commands to

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "coveralls": "^3.0.2",
+    "coveralls": "~3.0.2",
     "eslint": "^5.8.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:watch": "npm run test -- -w ./lib",
     "lint": "eslint ./lib ./test --ext .js",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
+    "test:coveralls": "npm run test:coverage && && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:watch": "npm run test -- -w ./lib",
     "lint": "eslint ./lib ./test --ext .js",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
-    "test:coveralls": "npm run test:coverage && && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
+    "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "license": "GPL-3.0",
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "coveralls": "^3.0.2",
     "eslint": "^5.8.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
Expose Code Coverage results to Coveralls. Runs `npm test:coverage` after the unit tests and then sends the results to [coveralls](https://coveralls.io)

the repo needs to be exposed on coveralls as well (obviously) - see https://coveralls.io/repos/new

- SHOULD requirement from TSC