### PR TITLE
Expose North Port

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,5 +70,8 @@ RUN \
 USER node
 ENV NODE_ENV=production
 
+# Expose 4041 for NORTH PORT
+EXPOSE ${IOTA_NORTH_PORT:-4041}
+
 ENTRYPOINT ["pm2-runtime", "bin/iotagent-lora"]
 CMD ["-- ", "config.js"]


### PR DESCRIPTION
LoRaWAN Equivalent of https://github.com/telefonicaid/iotagent-ul/pull/342 (maybe?)

I'm not sure if you need another port exposed by default, or is it all done in the `conf` for now.

Note that your default `config.js` states port 4061, the `README` of the `Dockerfile` states 4041 - I'm not quite sure which should be the default.