### PR TITLE
Update library version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iotagent-lora",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "IoT Agent for LoRaWAN protocol",
   "main": "lib/iotagent-lora",
   "scripts": {
@@ -26,7 +26,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "cbor-sync": "^1.0.3",
-    "iotagent-node-lib": "git://github.com/dcalvoalonso/iotagent-node-lib#task/configurationMgmt",
+    "iotagent-node-lib": "2.9.0",
     "mqtt": "^2.18.8",
     "request": "^2.88.0",
     "winston": "^3.1.0"


### PR DESCRIPTION
Since the **IoT Node Agent** lib has been updated, **LoRaWAN** should also create a new release is possible to keep in alignment.

Compare the change with the [Sigfox IoT Agent](https://github.com/telefonicaid/sigfox-iotagent/commit/d9d4b1e7480328cc61c88b03074f91f087f592e5#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)

**Note:** this change fixes the library back to  specific version, you may need to revert after tagging the release to track latest.