### PR TITLE
Fixes interface with LoraServer.io

### DIFF
--- a/docs/data_models.md
+++ b/docs/data_models.md
@@ -1,0 +1,37 @@
+# Data Models
+
+Currently, the FIWARE LoRaWAN IoT agent implements the following data models:
+
+-   [CayenneLpp](https://mydevices.com/cayenne/docs/lora/#lora-cayenne-low-power-payload)
+-   [IETF CBOR](https://tools.ietf.org/html/rfc7049)
+-   The payload is directly decoded by the LoRaWAN application server.
+
+The data model must be indicated during the device or group provisioning by means of the _data_model_ field within
+_lorawan_ field:
+
+| Data model         | data_model payload value |
+| ------------------ | ------------------------ |
+| CayenneLpp         | cayennelpp               |
+| IETF CBOR          | cbor                     |
+| Application server | application_server       |
+
+## CayenneLpp
+
+If this CayenneLpp is used by LoRaWAN devices in order to encode the payload data, the attributes include in device or
+group provisioning must match the _data channel_ and the _type_ used, following the pattern **{type}\_{data channel}**.
+Regarding the _type_ the following convention is used:
+
+| CayenneLpp type     | IoT Agent attribute | IoT Agent attribute example |
+| ------------------- | ------------------- | --------------------------- |
+| Digital input       | digital_in          | digital_in_0                |
+| Digital output      | digital_out         | digital_out_5               |
+| Analog input        | analog_in           | analog_in_2                 |
+| Analog output       | analog_out          | analog_out_9                |
+| Luminosity          | luminosity          | luminosity_4                |
+| Presence            | presence            | presence_7                  |
+| Temperature         | temperature         | temperature_0               |
+| Relative humidity   | relative_humidity   | relative_humidity_1         |
+| Accerelometer       | accelerometer       | accelerometer_2             |
+| Barometric pressure | barometric_pressure | barometric_pressure_1       |
+| Gyrometer           | gyrometer           | gyrometer_7                 |
+| GPS                 | gps                 | gps_0                       |

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -113,7 +113,7 @@ EOF
 -   provider: Identifies the LoRaWAN stack. **Current possible value is TTN.**
 -   data_model: Identifies the data model used by the device to report new observations. **Current possible values are
     cayennelpp,cbor and application_server. The last one can be used in case the payload format decoding is done by the
-    application server.**
+    application server. See [data models](data_models.md) for further information.**
 
 The IoTa will automatically subscribe to new observation notifications from the device. Whenever a new update is
 received, it will be translated to NGSI and forwarded to the Orion Context Broker.

--- a/lib/applicationServers/loraserverioAppService.js
+++ b/lib/applicationServers/loraserverioAppService.js
@@ -140,7 +140,7 @@ class LoraserverIoService extends appService.AbstractAppService {
             throw new Error('Missing mandatory configuration attributes for lorawan:dev_eui');
         }
 
-        var mqttTopic = 'application/' + this.applicationId + '/node/' + devEUI.toLowerCase() + '/rx';
+        var mqttTopic = 'application/' + this.applicationId + '/device/' + devEUI.toLowerCase() + '/rx';
         this.mqttClient.subscribeTopic(mqttTopic);
         winston.info('Mqtt topic subscribed:%s', mqttTopic);
     }
@@ -153,7 +153,7 @@ class LoraserverIoService extends appService.AbstractAppService {
      * @param      {<type>}  deviceObject  The device object
      */
     stopObservingDevice(devId, devEUI, deviceObject) {
-        var mqttTopic = 'application/' + this.applicationId + '/node/' + devEUI.toLowerCase() + '/rx';
+        var mqttTopic = 'application/' + this.applicationId + '/device/' + devEUI.toLowerCase() + '/rx';
         this.mqttClient.unSubscribeTopic(mqttTopic);
         winston.info('Mqtt topic unsubscribed:%s', mqttTopic);
     }
@@ -162,7 +162,7 @@ class LoraserverIoService extends appService.AbstractAppService {
      * It observes all devices
      */
     observeAllDevices() {
-        var mqttTopic = 'application/' + this.applicationId + '/node/+/rx';
+        var mqttTopic = 'application/' + this.applicationId + '/device/+/rx';
         this.mqttClient.subscribeTopic(mqttTopic);
         winston.info('Mqtt topic subscribed:%s', mqttTopic);
     }
@@ -171,7 +171,7 @@ class LoraserverIoService extends appService.AbstractAppService {
      * It stops observing all devices.
      */
     stopObserveAllDevices() {
-        var mqttTopic = 'application/' + this.applicationId + '/node/+/rx';
+        var mqttTopic = 'application/' + this.applicationId + '/device/+/rx';
         this.mqttClient.unSubscribeTopic(mqttTopic);
         winston.info('Mqtt topic unsubscribed:%s', mqttTopic);
     }

--- a/test/unit/deviceProvisioningLoRaServerIo.js
+++ b/test/unit/deviceProvisioningLoRaServerIo.js
@@ -149,7 +149,7 @@ describe('Device provisioning API: Provision devices', function() {
                 client.publish(
                     'application/' +
                         options.json.devices[0]['internal_attributes']['lorawan']['application_id'] +
-                        '/node/' +
+                        '/device/' +
                         options.json.devices[0]['internal_attributes']['lorawan']['dev_eui'].toLowerCase() +
                         '/rx',
                     JSON.stringify(attributesExample)
@@ -240,7 +240,7 @@ describe('Device provisioning API: Provision devices', function() {
                 client.publish(
                     'application/' +
                         options.json.devices[0]['internal_attributes']['lorawan']['application_id'] +
-                        '/node/' +
+                        '/device/' +
                         options.json.devices[0]['internal_attributes']['lorawan']['dev_eui'].toLowerCase() +
                         '/rx',
                     JSON.stringify(attributesExample)
@@ -266,7 +266,7 @@ describe('Device provisioning API: Provision devices', function() {
             var attributesExample = utils.readExampleFile('./test/activeAttributes/cayenneLpp_bad_json.json', true);
             var client = mqtt.connect('mqtt://' + testMosquittoHost);
             client.on('connect', function() {
-                client.publish('application/1/node/3339343752356A14/rx', JSON.stringify(attributesExample));
+                client.publish('application/1/device/3339343752356A14/rx', JSON.stringify(attributesExample));
                 setTimeout(function() {
                     client.end();
                     done();
@@ -281,7 +281,7 @@ describe('Device provisioning API: Provision devices', function() {
             );
             var client = mqtt.connect('mqtt://' + testMosquittoHost);
             client.on('connect', function() {
-                client.publish('application/1/node/3339343752356A14/rx', JSON.stringify(attributesExample));
+                client.publish('application/1/device/3339343752356A14/rx', JSON.stringify(attributesExample));
                 setTimeout(function() {
                     client.end();
                     done();

--- a/test/unit/groupProvisioningLoRaServerIo.js
+++ b/test/unit/groupProvisioningLoRaServerIo.js
@@ -190,7 +190,7 @@ describe('Configuration provisioning API: Provision groups', function() {
                 client.publish(
                     'application/' +
                         options.json.services[0]['internal_attributes']['lorawan']['application_id'] +
-                        '/node/' +
+                        '/device/' +
                         attributesExample.devEUI +
                         '/rx',
                     JSON.stringify(attributesExample)
@@ -218,7 +218,7 @@ describe('Configuration provisioning API: Provision groups', function() {
                 client.publish(
                     'application/' +
                         options.json.services[0]['internal_attributes']['lorawan']['application_id'] +
-                        '/node/' +
+                        '/device/' +
                         attributesExample.devEUI +
                         '/rx',
                     JSON.stringify(attributesExample)
@@ -300,7 +300,7 @@ describe('Configuration provisioning API: Provision groups', function() {
                     client.publish(
                         'application/' +
                             options.json.services[0]['internal_attributes']['lorawan']['application_id'] +
-                            '/node/' +
+                            '/device/' +
                             attributesExample.devEUI +
                             '/rx',
                         JSON.stringify(attributesExample)

--- a/test/unit/staticProvisioningLoRaServerIo.js
+++ b/test/unit/staticProvisioningLoRaServerIo.js
@@ -195,7 +195,7 @@ describe('Static provisioning', function() {
                 client.publish(
                     'application/' +
                         sensorType['internalAttributes']['lorawan']['application_id'] +
-                        '/node/' +
+                        '/device/' +
                         attributesExample.devEUI +
                         '/rx',
                     JSON.stringify(attributesExample)


### PR DESCRIPTION
It seems that after the release of v1.0.0, LoRaServer.io has changed the topics:
> Note: for versions before v1.0.0 .../device/.. was configured as .../node/....
Therefore:
- MQTT topics updated to versions after v1