### PR TITLE
WIP: allows to register services without lorawan attributes

### DIFF
--- a/lib/iotagent-lora.js
+++ b/lib/iotagent-lora.js
@@ -547,8 +547,8 @@ function loadTypesFromConfig(callback) {
 
         async.eachSeries(arrayTypes, registerConfigType, function(err) {
             if (err) {
-                winston.error('Error loading services from configuration file', err);
-                return callback(err);
+                winston.warn('Error loading services from configuration file', err);
+                return callback();
             } else {
                 return callback(null);
             }
@@ -573,8 +573,8 @@ function loadServices(callback) {
         if (services.count > 0 && services.services.length > 0) {
             async.eachSeries(services.services, registerConfiguration, function(err) {
                 if (err) {
-                    winston.error('Error loading services', err);
-                    return callback(err);
+                    winston.warn('Error loading services', err);
+                    return callback();
                 } else {
                     return callback();
                 }
@@ -599,8 +599,8 @@ function loadDevices(callback) {
         if (devices) {
             async.eachSeries(devices.devices, registerDevice, function(err) {
                 if (err) {
-                    winston.error('Error loading devices', err);
-                    return callback(err);
+                    winston.warn('Error loading devices', err);
+                    return callback();
                 } else {
                     return callback();
                 }


### PR DESCRIPTION
suppose lorawan attributes are specific for device, but you would like still to put in a common factor some configuration (e.g. attributes), the agent should allow for that.