### PR TITLE
Add PM2_ENABLED flag to Docker

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -147,6 +147,19 @@ COPY . /opt/iotagent-lora/
 
 Full instructions can be found within the `Dockerfile` itself.
 
+### Using PM2
+
+The IoT Agent within the Docker image can be run encapsulated within the [pm2](http://pm2.keymetrics.io/) Process
+Manager by adding the `PM2_ENABLED` environment variable.
+
+```console
+docker run --name iotagent -e PM2_ENABLED=true -d fiware/iotagent-lorawan
+```
+
+Use of pm2 is **disabled** by default. It is unnecessary and counterproductive to add an additional process manager if
+your dockerized environment is already configured to restart Node.js processes whenever they exit (e.g. when using
+Kubenetes)
+
 ### Docker Secrets
 
 As an alternative to passing sensitive information via environment variables, `_FILE` may be appended to some sensitive

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -62,4 +62,12 @@ else
     fi
 fi
 
-pm2-runtime /opt/iotagent-lora/bin/iotagent-lora
+if [[  -z "$PM2_ENABLED" ]]; then
+    echo "INFO: IoT Agent running standalone"
+    node /opt/iotagent-lora/bin/iotagent-lora
+else
+    echo "***********************************************"
+    echo "INFO: IoT Agent encapsulated by pm2-runtime see https://pm2.io/doc/en/runtime/integration/docker/"
+    echo "***********************************************"
+    pm2-runtime /opt/iotagent-lora/bin/iotagent-lora
+fi


### PR DESCRIPTION
This PR is a potential fix for https://github.com/telefonicaid/iotagent-node-lib/issues/790

* Update entrypoint to use/not use pm2
* Add `PM2_ENABLED` to Docker README