### PR TITLE
Bump to node 10

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@
 # License along with iotagent-lora. If not, see http://www.gnu.org/licenses/.
 #
 
-ARG NODE_VERSION=10.17.0-slim
+ARG NODE_VERSION=10.19.0-slim
 FROM node:${NODE_VERSION}
 ARG GITHUB_ACCOUNT=Atos-Research-and-Innovation
 ARG GITHUB_REPOSITORY=IoTagent-LoRaWAN

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@
 # License along with iotagent-lora. If not, see http://www.gnu.org/licenses/.
 #
 
-ARG NODE_VERSION=8.16.1-slim
+ARG NODE_VERSION=10.17.0-slim
 FROM node:${NODE_VERSION}
 ARG GITHUB_ACCOUNT=Atos-Research-and-Innovation
 ARG GITHUB_REPOSITORY=IoTagent-LoRaWAN


### PR DESCRIPTION
Node 8 leaves LTS at the end of the year. The default node version should be switched to Node Dubnium for the upcoming December FIWARE 7.8.1 Patch release.