### PR TITLE
Update texts LoRa Server=>ChirpStack

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ architecture, providing interoperability between FIWARE NGSI Context Brokers and
 ### Supported stacks
 
 -   [The Things Network](https://www.thethingsnetwork.org/)
--   [LoRaServer](https://www.loraserver.io/)
+-   [ChirpStack](https://www.chirpstack.io/)
 
 ### Data models
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -17,13 +17,13 @@
     -   Username: It is the Application ID.
     -   Password (step 3)
 
-## LoRaServer.io
+## ChirpStack.io
 
 1.  Install/deploy LoRa Server project. Docker installation method is recommended:
-    `https://www.loraserver.io/install/docker/`
-2.  Follow the [Getting started](https://www.loraserver.io/use/getting-started/) page to register your network-server
+    `https://www.chirpstack.io/install/docker/`
+2.  Follow the [Getting started](https://www.chirpstack.io/use/getting-started/) page to register your network-server
     and to create a service-profile, gateway, device-profile, application. Finally, add your LoRaWAN devices. Register
-    your network-server: `https://www.loraserver.io/lora-app-server/use/network-servers/`
+    your network-server: `https://www.chirpstack.io/lora-app-server/use/network-servers/`
 3.  In order to use FIWARE IoT Agent for LoRaWAN protocol, you will need the following information:
 
 -   Application ID


### PR DESCRIPTION
The project has changed its name to ChirpStack - formerly known as LoRa Server, see [announcement](https://forum.chirpstack.io/t/rename-to-chirpstack-announcement/6473)

> As you probably have guessed already, ChirpStack is the new name for what was known as the
> LoRa Server project. Since the start, in 2016, the project has gained a lot of traction and is now
> being used by thousands of users around the world. Unfortunately due to unknown trademark
> conflicts when we started this project, we must change the name as “LoRa” is a trademark
> registered by Semtech.