### PR TITLE
Fixed user_manual and docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "3.5"
 
 volumes:
   mongo_data:
@@ -36,6 +36,6 @@ services:
     hostname: iotagent-lora
     image: ioeari/iotagent-lora
     ports:
-      - "4061:4061"
+      - "4041:4041"
     stdin_open: true
     tty: true

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -54,7 +54,7 @@ This option allows provisioning a specific device, describing its attributes and
 single Application Server, we can provision devices reporting different types of measurements.**
 
 ```bash
-curl localhost:4061/iot/devices -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'fiware-service: smartgondor' --header 'fiware-servicepath: /gardens' -d @- <<EOF
+curl localhost:4041/iot/devices -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'fiware-service: smartgondor' --header 'fiware-servicepath: /gardens' -d @- <<EOF
 {
   "devices": [
     {
@@ -92,7 +92,7 @@ curl localhost:4061/iot/devices -s -S --header 'Content-Type: application/json' 
       "internal_attributes": {
         "lorawan": {
           "application_server": {
-            "host": "eu.thethings.network",",
+            "host": "eu.thethings.network",
             "username": "ari_ioe_app_demo1",
             "password": "pwd1",
             "provider": "TTN"
@@ -110,10 +110,9 @@ curl localhost:4061/iot/devices -s -S --header 'Content-Type: application/json' 
 EOF
 ```
 
--   provider: Identifies the LoRaWAN stack. **Current possible value is TTN.**
--   data_model: Identifies the data model used by the device to report new observations. **Current possible values are
-    cayennelpp,cbor and application_server. The last one can be used in case the payload format decoding is done by the
-    application server. See [data models](./data_models.md) for further information.**
+-   `provider`: Identifies the LoRaWAN stack. **Current possible value are `TTN` and `loraserver.io`.**
+-   `data_model`: Identifies the data model used by the device to report new observations. **Current possible values are
+    `cayennelpp`, `cbor` and `application_server`. The last one can be used in case the payload format decoding is done by the application server. See [data models](./data_models.md) for further information.**
 
 The IoTa will automatically subscribe to new observation notifications from the device. Whenever a new update is
 received, it will be translated to NGSI and forwarded to the Orion Context Broker.
@@ -131,7 +130,7 @@ _configuration API_ can be used to pre-provision all of them with a single reque
 sharing the same configuration must be registered under the same Application Server.**
 
 ```bash
-curl localhost:4061/iot/services -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'fiware-service: smartgondor' --header 'fiware-servicepath: /gardens' -d @- <<EOF
+curl localhost:4041/iot/services -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'fiware-service: smartgondor' --header 'fiware-servicepath: /gardens' -d @- <<EOF
 {
 	"services": [
    {


### PR DESCRIPTION
The manual used 4061 and also the docker-compose.yml used this port, but the correct port is 4041. So I reflected this in the manual and the compose file. 

There was also a syntax error in the example post request for registering a new LoRa Device and the provider for the loraserver was missing. 

Best regards
it7760 