### PR TITLE
Support for protocol, port and mqtt client options when setting up lorawan configuration (#135)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ ARG GITHUB_REPOSITORY=IoTagent-LoRaWAN
 ARG DOWNLOAD=latest
 ARG SOURCE_BRANCH=master
 
-# Copying Build time arguments to environment variables so they are persisted at run time and can be 
+# Copying Build time arguments to environment variables so they are persisted at run time and can be
 # inspected within a running container.
 # see: https://vsupalov.com/docker-build-time-env-values/  for a deeper explanation.
 
@@ -34,7 +34,7 @@ ENV DOWNLOAD=${DOWNLOAD}
 
 MAINTAINER FIWARE IoTAgent Team. Atos Spain S.A
 
-# IMPORTANT: For production environments use Docker Secrets to protect values of the sensitive ENV 
+# IMPORTANT: For production environments use Docker Secrets to protect values of the sensitive ENV
 # variables defined below, by adding _FILE to the name of the relevant variable.
 #
 # - IOTA_AUTH_USER, IOTA_AUTH_PASSWORD - when using Keystone Security
@@ -42,7 +42,7 @@ MAINTAINER FIWARE IoTAgent Team. Atos Spain S.A
 
 #
 # The following RUN command retrieves the source code from GitHub.
-# 
+#
 # To obtain the latest stable release run this Docker file with the parameters
 # --no-cache --build-arg DOWNLOAD=stable
 # To obtain any speciifc version of a release run this Docker file with the parameters
@@ -50,7 +50,7 @@ MAINTAINER FIWARE IoTAgent Team. Atos Spain S.A
 #
 # The default download is the latest tip of the master of the named repository on GitHub
 #
-# Alternatively for local development, just copy this Dockerfile into file the root of the repository and 
+# Alternatively for local development, just copy this Dockerfile into file the root of the repository and
 # replace the whole RUN statement by the following COPY statement in your local source using :
 #
 # COPY . /opt/iotagent-lora/

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,0 +1,48 @@
+#
+# Copyright 2019 Atos Spain S.A
+#
+# This file is part of iotagent-lora
+#
+# iotagent-lora is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the License,
+# or (at your option) any later version.
+#
+# iotagent-lora is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with iotagent-lora. If not, see http://www.gnu.org/licenses/.
+#
+
+ARG NODE_VERSION=8.16.1-slim
+
+FROM node:${NODE_VERSION}
+
+COPY . /opt/iotagent-lora/
+
+WORKDIR /opt/iotagent-lora
+
+RUN \
+	# Ensure that Git is installed prior to running npm install
+	apt-get update && \
+	apt-get install -y git  && \
+	npm install pm2@3.2.2 -g && \
+	echo "INFO: npm install --production..." && \
+	npm install --production && \
+	# Remove Git and clean apt cache
+	apt-get clean && \
+	apt-get remove -y git && \
+	apt-get -y autoremove  && \
+	chmod +x docker/entrypoint.sh
+
+USER node
+ENV NODE_ENV=production
+
+# Expose 4041 for NORTH PORT
+EXPOSE ${IOTA_NORTH_PORT:-4041}
+
+ENTRYPOINT ["docker/entrypoint.sh"]
+CMD ["-- ", "config.js"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ architecture, providing interoperability between FIWARE NGSI Context Brokers and
 ### Supported stacks
 
 -   [The Things Network](https://www.thethingsnetwork.org/)
--   [LoRaServer](https://www.loraserver.io/)
+-   [LoRaServer](https://www.chirpstack.io/)
 
 ### Data models
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -17,13 +17,13 @@
     -   Username: It is the Application ID.
     -   Password (step 3)
 
-## LoRaServer.io
+## ChirpStack
 
 1.  Install/deploy LoRa Server project. Docker installation method is recommended:
-    `https://www.loraserver.io/install/docker/`
-2.  Follow the [Getting started](https://www.loraserver.io/use/getting-started/) page to register your network-server
-    and to create a service-profile, gateway, device-profile, application. Finally, add your LoRaWAN devices. Register
-    your network-server: `https://www.loraserver.io/lora-app-server/use/network-servers/`
+    `https://www.chirpstack.io/install/docker/`
+2.  Follow the [Getting started](https://www.chirpstack.io/project/guides/first-gateway-device/) page to register your
+    network-server and to create a service-profile, gateway, device-profile, application. Finally, add your LoRaWAN
+    devices. Register your network-server: `https://www.chirpstack.io/application-server/use/network-servers/`
 3.  In order to use FIWARE IoT Agent for LoRaWAN protocol, you will need the following information:
 
 -   Application ID

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -130,6 +130,9 @@ If a group of devices reports the same observations (i.e., smart meters for a ne
 _configuration API_ can be used to pre-provision all of them with a single request.**With this approach, all the devices
 sharing the same configuration must be registered under the same Application Server.**
 
+**Note: in this case, you need to use the `app_eui` as the `resource` field, in order for devices to be correctly
+provisioned under this service.**
+
 ```bash
 curl localhost:4061/iot/services -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'fiware-service: smartgondor' --header 'fiware-servicepath: /gardens' -d @- <<EOF
 {

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -171,7 +171,7 @@ curl localhost:4061/iot/services -s -S --header 'Content-Type: application/json'
     "internal_attributes": {
         "lorawan": {
           "application_server": {
-            "host": "eu.thethings.network",",
+            "host": "eu.thethings.network",
             "username": "ari_ioe_app_demo1",
             "password": "pwd1",
             "provider": "TTN"
@@ -193,6 +193,75 @@ In this case, the IoTA will subscribe to any observation coming from the LoRaWAN
 update arrives, it will create the corresponding device internally and also in the Context Broker using the
 pre-provisioned configuration. Finally, it will forward appropriate context update requests to the Context Broker to
 update the attributes' values.
+
+## Connecting to secure lora servers
+
+If the lora server can only be accessed through a secure protocol like MQTTS for example, both protocol and port can be
+defined in the `application_server` field of the configuration.
+
+```bash
+curl localhost:4061/iot/services -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'fiware-service: smartgondor' --header 'fiware-servicepath: /gardens' -d @- <<EOF
+{
+	"services": [
+   {
+    "entity_type": "LoraDeviceGroup",
+    "apikey": "",
+    "resource": "4569343567897875",
+    "attributes": [
+      {
+        "object_id": "bp0",
+        "name": "barometric_pressure_0",
+        "type": "Number"
+      },
+      {
+        "object_id": "di3",
+        "name": "digital_in_3",
+        "type": "Number"
+      },
+      {
+        "object_id": "do4",
+        "name": "digital_out_4",
+        "type": "Number"
+      },
+      {
+        "object_id": "rh2",
+        "name": "relative_humidity_2",
+        "type": "Number"
+      },
+      {
+        "object_id": "t1",
+        "name": "temperature_1",
+        "type": "Number"
+      }
+    ],
+    "internal_attributes": {
+        "lorawan": {
+          "application_server": {
+            "host": "some.secure.server",
+            "protocol": "mqtts",
+            "port": 8883,
+            "username": "ari_ioe_app_demo1",
+            "password": "pwd1",
+            "provider": "TTN",
+            "options": {
+              "keepalive": 60
+            }
+          },
+          "app_eui": "4569343567897875",
+          "application_id": "ari_ioe_app_demo1",
+          "application_key": "444B8EF16415B5F6ED777EAFE695C49",
+          "data_model": "cayennelpp"
+    }
+  }
+]
+}
+EOF
+```
+
+Both the `protocol` and `port` can be specified (otherwise they default to the default mqtt protocol and port), as well
+as the `options` field, which is an object containing some additional options used by the agent's MQTT client. For a
+full reference of all the options available, see the
+[MQTT Client Documentation](https://github.com/mqttjs/MQTT.js/#mqttclientstreambuilder-options)
 
 ## Static configuration
 

--- a/lib/applicationServers/loraserverioAppService.js
+++ b/lib/applicationServers/loraserverioAppService.js
@@ -65,8 +65,11 @@ class LoraserverIoService extends appService.AbstractAppService {
         this.preProcessMessage = this.preProcessMessage.bind(this);
         this.mqttClient = new mqttClient.MqttClient(
             this.applicationServer.host,
+            this.applicationServer.port,
+            this.applicationServer.protocol,
             this.applicationServer.username,
             this.applicationServer.password,
+            this.applicationServer.options,
             this.preProcessMessage
         );
 
@@ -90,8 +93,8 @@ class LoraserverIoService extends appService.AbstractAppService {
      * @param      {<type>}  message    The message
      */
     preProcessMessage(mqttTopic, message) {
-        winston.info('New message in topic', mqttTopic);
-        winston.debug('Message', JSON.stringify(message));
+        winston.info('New message in topic %s', mqttTopic);
+        winston.debug('Message: %s', message);
 
         var splittedMqttTopic = mqttTopic.split('/');
         if (splittedMqttTopic.length !== 5) {

--- a/lib/applicationServers/ttnAppService.js
+++ b/lib/applicationServers/ttnAppService.js
@@ -65,8 +65,11 @@ class TtnAppService extends appService.AbstractAppService {
         this.preProcessMessage = this.preProcessMessage.bind(this);
         this.mqttClient = new mqttClient.MqttClient(
             this.applicationServer.host,
+            this.applicationServer.port,
+            this.applicationServer.protocol,
             this.applicationServer.username,
             this.applicationServer.password,
+            this.applicationServer.options,
             this.preProcessMessage
         );
 
@@ -90,7 +93,9 @@ class TtnAppService extends appService.AbstractAppService {
      * @param      {<type>}  message    The message
      */
     preProcessMessage(mqttTopic, message) {
-        winston.info('New message in topic', mqttTopic);
+        winston.info('New message in topic %s', mqttTopic);
+        winston.debug('Message: %s', message);
+
         var splittedMqttTopic = mqttTopic.split('/');
         if (splittedMqttTopic.length !== 4) {
             var errorMessage = 'Bad format for a TTN topic';

--- a/lib/bindings/mqttClient.js
+++ b/lib/bindings/mqttClient.js
@@ -44,8 +44,14 @@ class MqttClient {
         }
 
         this.host = host;
-        this.port = port;
-        this.protocol = protocol;
+        this.port = 1883;
+        if (port) {
+            this.port = port;
+        }
+        this.protocol = 'mqtt';
+        if (protocol) {
+            this.protocol = protocol;
+        }
         this.options = {};
         if (options && typeof options === 'object') {
             this.options = options;

--- a/lib/bindings/mqttClient.js
+++ b/lib/bindings/mqttClient.js
@@ -32,18 +32,27 @@ class MqttClient {
      * Constructs the object.
      *
      * @param      {<type>}  host      The host
+     * @param      {<type>}  port      The port
+     * @param      {<type>}  protocol  The protocol
      * @param      {<type>}  username  The username
      * @param      {<type>}  password  The password
      * @param      {<type>}  listener  The listener
      */
-    constructor(host, username, password, listener) {
+    constructor(host, port, protocol, username, password, options, listener) {
         if (!host || !listener) {
             throw new Error('Invalid arguments');
         }
 
         this.host = host;
-        this.username = username;
-        this.password = password;
+        this.port = port;
+        this.protocol = protocol;
+        this.options = {};
+        if (options && typeof options === 'object') {
+            this.options = options;
+        }
+
+        this.options.username = username;
+        this.options.password = password;
         this.topics = {};
         this.listener = listener;
     }
@@ -54,16 +63,13 @@ class MqttClient {
      * @param      {Function}  callback  The callback
      */
     start(callback) {
-        var host = 'mqtt://' + this.host;
-        var options = {};
-        options.username = this.username;
-        options.password = this.password;
+        var host = this.protocol + '://' + this.host + ':' + this.port;
         var connected = false;
 
-        winston.info('Connecting to MQTT server %s with options:%s', host, JSON.stringify(options));
+        winston.info('Connecting to MQTT server %s with options:%s', host, JSON.stringify(this.options));
         this.mqttClient = mqtt.connect(
             host,
-            options
+            this.options
         );
         this.mqttClient.on('error', function(error) {
             winston.error('Error connecting to MQTT server:' + JSON.stringify(error));

--- a/lib/iotagent-lora.js
+++ b/lib/iotagent-lora.js
@@ -294,7 +294,10 @@ function registerApplicationServer(appServerConf, iotaConfiguration, callback) {
             appServerConf.lorawan.data_model,
             iotaConfiguration
         );
-    } else if (appServerConf.lorawan.application_server.provider === 'loraserver.io') {
+    } else if (
+        appServerConf.lorawan.application_server.provider === 'loraserver.io' ||
+        appServerConf.lorawan.application_server.provider === 'chirpstack'
+    ) {
         newApp = new loraserverioAppService.LoraserverIoService(
             appServerConf.lorawan.application_server,
             appServerConf.lorawan.app_eui,
@@ -305,7 +308,7 @@ function registerApplicationServer(appServerConf, iotaConfiguration, callback) {
             iotaConfiguration
         );
     } else {
-        error = 'Unsupported provider for application server. Supported values: TTN and loraserver.io';
+        error = 'Unsupported provider for application server. Supported values: TTN, loraserver.io and chirpstack';
         winston.error(error);
         return callback(error);
     }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "^2.6.1",
     "cbor-sync": "^1.0.3",
     "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
-    "mqtt": "^2.18.8",
+    "mqtt": "^4.1.0",
     "request": "^2.88.0",
     "winston": "^3.1.0"
   },


### PR DESCRIPTION
- Can now write, protocol, port and mqtt options when providing the lorawan configuration. This to enable the use of secure protocols like mqtts and ssl when connecting to a lorawan server.
- Chirpstack is now replacing lowaran.io, so the ability to use that as a provider in configuration is also an option (uses the same files as lorawan.io).
- Updated mqtt library to latest version.
- Documentation updated to reflect the changes.

