### PR TITLE
fix support for device configuration groups (#102)

### DIFF
--- a/lib/iotagent-lora.js
+++ b/lib/iotagent-lora.js
@@ -41,13 +41,29 @@ var loraApps = [];
  */
 function loadConfigurationFromAppserver(appServer, callback) {
     if (!appServer.getIotaConfiguration()) {
-        return iotAgentLib.getConfiguration(appServer.getAppId(), '', callback);
+        return iotAgentLib.getConfiguration(appServer.getAppId(), '', function(error, group) {
+            if (!error && group) {
+                callback(null, group);
+            } else if (error.name === 'DEVICE_GROUP_NOT_FOUND') {
+                callback(null, null);
+            } else {
+                callback(error);
+            }
+        });
     } else {
         var conf = appServer.getIotaConfiguration();
         if (!conf.resource) {
             return callback(null, conf);
         } else {
-            return iotAgentLib.getConfiguration(appServer.getAppId(), '', callback);
+            return iotAgentLib.getConfiguration(appServer.getAppId(), '', function(error, group) {
+                if (!error && group) {
+                    callback(null, group);
+                } else if (error.name === 'DEVICE_GROUP_NOT_FOUND') {
+                    callback(null, null);
+                } else {
+                    callback(error);
+                }
+            });
         }
     }
 }
@@ -134,52 +150,40 @@ function messageHandler(appServer, deviceId, deviceEui, message) {
     if (!deviceObject) {
         winston.info('LoRaWAN device unprovisioned');
         winston.debug('Looking for group:' + appServer.getAppId());
-        async.waterfall(
-            [
-                async.apply(loadConfigurationFromAppserver, appServer),
-                async.apply(registerDeviceFromConfiguration, deviceId, deviceEui)
-            ],
-            function(error, device) {
-                if (error) {
-                    winston.error(error);
-                } else if (device) {
-                    appServer.addDevice(device.id, deviceEui, device);
-                    var ngsiMessage = dataTranslation.toNgsi(message, device);
-                    if (ngsiMessage && ngsiMessage instanceof Array && ngsiMessage.length > 0) {
-                        iotAgentLib.update(device.name, device.type, '', ngsiMessage, device, function(iotaError) {
-                            if (iotaError) {
-                                errorMessage =
-                                    "Couldn't send the updated values to the Context Broker due to an error:";
-                                winston.error(errorMessage, JSON.stringify(iotaError));
-                            } else {
-                                winston.info('Observations sent to CB successfully for device ', deviceId);
-                            }
-                        });
-                    } else {
-                        errorMessage = 'Could not cast message to NGSI';
-                        winston.error(errorMessage);
-                    }
-                } else {
-                    errorMessage = 'Unexpected error';
-                    winston.error(errorMessage);
-                }
+        const internalAttrs = new Array();
+        internalAttrs[0] = {
+            lorawan: {
+                dev_eui: deviceEui
             }
-        );
+        };
+
+        deviceObject = {
+            id: deviceId,
+            internalAttributes: internalAttrs
+        };
     } else {
-        iotAgentLib.getDevice(deviceId, deviceObject.service, deviceObject.subservice, function(error, device) {
+        var eui = findLorawanInternalAttribute('dev_eui', deviceObject.internalAttributes);
+        if (eui != deviceEui) {
+            errorMessage = 'Registered device eui [%s] does not match message device eui [%s]';
+            winston.warn(errorMessage, eui, deviceEui);
+        }
+    }
+    async.waterfall(
+        [async.apply(loadConfigurationFromAppserver, appServer), async.apply(retrieveDevice, deviceObject)],
+        function(error, device) {
             if (error) {
-                errorMessage = 'Error getting IoTA device object';
+                errorMessage = 'Error getting IoTA device object: %s';
                 winston.error(errorMessage, JSON.stringify(error));
             } else if (device) {
-                winston.info('IOTA provisioned devices:', JSON.stringify(device));
+                if (!deviceObject) appServer.addDevice(device.id, deviceEui, device);
                 var ngsiMessage = dataTranslation.toNgsi(message, device);
                 if (ngsiMessage && ngsiMessage instanceof Array && ngsiMessage.length > 0) {
                     iotAgentLib.update(device.name, device.type, '', ngsiMessage, device, function(iotaError) {
                         if (iotaError) {
-                            errorMessage = "Couldn't send the updated values to the Context Broker due to an error:";
+                            errorMessage = "Couldn't send the updated values to the Context Broker due to an error: %s";
                             winston.error(errorMessage, JSON.stringify(iotaError));
                         } else {
-                            winston.info('Observations sent to CB successfully for device ', deviceId);
+                            winston.info('Observations sent to CB successfully for device: %s', deviceId);
                         }
                     });
                 } else {
@@ -187,11 +191,11 @@ function messageHandler(appServer, deviceId, deviceEui, message) {
                     winston.error(errorMessage);
                 }
             } else {
-                errorMessage = "Couldn't find device data for DeviceId " + deviceId;
+                errorMessage = 'Unexpected error';
                 winston.error(errorMessage);
             }
-        });
-    }
+        }
+    );
 }
 
 /**
@@ -360,7 +364,7 @@ function stopApplicationServers(callback) {
 function registerConfiguration(configuration, callback) {
     var error;
 
-    winston.info('Configuration provisioning:%s', JSON.stringify(configuration));
+    winston.info('Configuration provisioning: %s', JSON.stringify(configuration));
     if (!configuration.internalAttributes) {
         error = 'internal_attributes is mandatory to define specific agent configuration';
         winston.error(error);
@@ -427,7 +431,7 @@ function removeConfiguration(configuration, callback) {
 function registerDevice(device, callback) {
     var error;
 
-    winston.info('Device provisioning:%s', JSON.stringify(device));
+    winston.info('Device provisioning: %s', JSON.stringify(device));
 
     if (!device.internalAttributes) {
         error = 'internal_attributes is mandatory to define specific agent configuration';
@@ -448,6 +452,24 @@ function registerDevice(device, callback) {
         lorawanConf = device.internalAttributes;
     }
 
+    if (lorawanConf.lorawan && !lorawanConf.lorawan.dev_eui) {
+        error = 'Device %s does not include dev_eui: this information is required';
+        winston.error(error);
+        error = { message: error };
+        return callback(error);
+    }
+
+    if (lorawanConf.lorawan && !lorawanConf.lorawan.application_server) {
+        var appServer = getAppByDeviceGroup(device.service, device.subservice, device.apikey, device.resource);
+        if (appServer) {
+            error =
+                'Device %s does not include application_server configuration, but seems to be part of an existing device group';
+            winston.warn(error, device.id);
+            appServer.addDevice(device.id, lorawanConf.lorawan.dev_eui, device);
+            return callback(null, device);
+        }
+    }
+
     registerApplicationServer(lorawanConf, null, function(err, appServer) {
         if (err) {
             winston.error(error);
@@ -466,7 +488,7 @@ function registerDevice(device, callback) {
  * @param  {Function} callback The callback
  */
 function removeDevice(device, callback) {
-    winston.info('Removing device:%s', JSON.stringify(device));
+    winston.info('Removing device: %s', JSON.stringify(device));
     var lorawanConf = device.internalAttributes;
     for (var app in loraApps) {
         if (loraApps[app] instanceof appService.AbstractAppService) {
@@ -480,41 +502,149 @@ function removeDevice(device, callback) {
     return callback(null, device);
 }
 
-/**
- * It registers a new device using an already registered configuration
- *
- * @param      {string}    deviceId       The device identifier
- * @param      {string}    deviceEUI      The device EUI
- * @param      {Object}    configuration  The configuration
- * @param      {Function}  callback       The callback
- */
-function registerDeviceFromConfiguration(deviceId, deviceEUI, configuration, callback) {
-    var newDevice = {};
-
-    newDevice = {
-        id: deviceId,
-        name: deviceId + ':' + configuration.type,
-        type: configuration.type,
-        service: configuration.service,
-        subservice: configuration.subservice,
-        lazy: configuration.lazy,
-        active: configuration.attributes,
-        commands: configuration.commands,
-        internalAttributes: configuration.internalAttributes
-    };
-
-    if (newDevice.internalAttributes instanceof Array) {
-        for (var i = 0; i < newDevice.internalAttributes.length; i++) {
-            if (newDevice.internalAttributes[i].lorawan) {
-                newDevice.internalAttributes[i].lorawan.dev_eui = deviceEUI;
+function findLorawanInternalAttribute(name, internalAttributes) {
+    var attr;
+    if (internalAttributes && internalAttributes instanceof Array) {
+        for (var i = 0; i < internalAttributes.length; i++) {
+            if (internalAttributes[i].lorawan && internalAttributes[i].lorawan.hasOwnProperty(name)) {
+                attr = internalAttributes[i].lorawan[name];
                 break;
             }
         }
-    } else {
-        newDevice.internalAttributes.lorawan.dev_eui = deviceEUI;
+    } else if (internalAttributes && internalAttributes.lorawan && internalAttributes.lorawan.hasOwnProperty(name)) {
+        attr = internalAttributes.lorawan[name];
+    }
+    return attr;
+}
+
+/**
+ * Search a device from the device repository based DeviceID and group, creating one if none is
+ * found for the given data.
+ *
+ * @param {String} deviceId         Device ID of the device that wants to be retrieved or created.
+ * @param {String} group            Device Group.
+ */
+
+function findOrCreate(deviceObject, group, callback) {
+    if (!group && deviceObject.service && deviceObject.subservice) {
+        group = {
+            service: deviceObject.service,
+            subservice: deviceObject.subservice,
+            type: deviceObject.type
+        };
+    } else if (!group && !deviceObject.service && !deviceObject.subservice) {
+        group = {
+            service: null,
+            subservice: null,
+            type: null
+        };
     }
 
-    iotAgentLib.register(newDevice, callback);
+    iotAgentLib.getDevice(deviceObject.id, group.service, group.subservice, function(error, device) {
+        if (!error && device) {
+            callback(null, device, group);
+        } else if (error.name === 'DEVICE_NOT_FOUND' || error.name === 'DEVICE_GROUP_NOT_FOUND') {
+            const internalAttrs = new Array();
+            var dev_eui = findLorawanInternalAttribute('dev_eui', deviceObject.internalAttributes);
+            var data_model = findLorawanInternalAttribute('data_model', group.internalAttributes);
+
+            internalAttrs[0] = {
+                lorawan: {}
+            };
+
+            if (dev_eui) {
+                internalAttrs[0].lorawan.dev_eui = dev_eui;
+            }
+
+            if (data_model) {
+                internalAttrs[0].lorawan.data_model = data_model;
+            }
+
+            const newDevice = {
+                id: deviceObject.id,
+                name: deviceObject.id,
+                service: group.service,
+                subservice: group.subservice,
+                apikey: '',
+                resource: '',
+                internalAttributes: internalAttrs
+            };
+
+            if (group && group.type) {
+                newDevice.type = group.type;
+                newDevice.name = group.type + ':' + deviceObject.id;
+            }
+
+            if (group && group.apikey) {
+                newDevice.apikey = group.apikey;
+            }
+
+            if (group && group.resource) {
+                newDevice.resource = group.resource;
+            }
+
+            if (
+                config.getConfig().iota &&
+                config.getConfig().iota.iotManager &&
+                config.getConfig().iota.iotManager.protocol
+            ) {
+                newDevice.protocol = config.getConfig().iota.iotManager.protocol;
+            }
+            if (group && 'timestamp' in group) {
+                newDevice.timestamp = group.timestamp;
+            }
+            iotAgentLib.register(newDevice, function(error, device) {
+                callback(error, device, group);
+            });
+        } else {
+            callback(error);
+        }
+    });
+}
+
+/**
+ * Retrieve a device from the device repository based on the given Resource and
+ *  DeviceID, creating one if none is found for the given data.
+ *
+ * @param {String} deviceId         Device ID of the device that wants to be retrieved or created.
+ * @param {String} resource         Resource of the Device Group (or default Resource).
+ */
+function retrieveDevice(deviceObject, configuration, callback) {
+    if (configuration && configuration.resource && configuration.resource === config.getConfig().defaultResource) {
+        iotAgentLib.getDevicesByAttribute('id', deviceObject.id, null, null, function(error, devices) {
+            if (error) {
+                callback(error);
+            } else if (devices && devices.length === 1) {
+                callback(null, devices[0]);
+            } else {
+                winston.error(
+                    "Couldn't find device data for Resource [%s] and DeviceId [%s]",
+                    configuration.resource,
+                    deviceObject.id
+                );
+                error = {
+                    message:
+                        "Couldn't find device data for Resource " +
+                        configuration.resource +
+                        ' and DeviceId ' +
+                        deviceObject.id
+                };
+                callback(error);
+            }
+        });
+    } else {
+        async.waterfall(
+            [
+                async.apply(findOrCreate, deviceObject, configuration),
+                async.apply(
+                    iotAgentLib.mergeDeviceWithConfiguration,
+                    ['lazy', 'active', 'staticAttributes', 'internalAttributes', 'commands', 'subscriptions'],
+                    [null, null, [], [], [], [], []]
+                )
+            ],
+            callback
+        );
+    }
 }
 
 /**
@@ -542,12 +672,17 @@ function loadTypesFromConfig(callback) {
                 var newType = config.getConfig().iota.types[type];
                 newType['type'] = type;
                 arrayTypes.push(newType);
+            } else {
+                winston.warn('Type [%s] does not contain lorawan config, it will not be loaded', type);
             }
         }
 
         async.eachSeries(arrayTypes, registerConfigType, function(err) {
             if (err) {
-                winston.error('Error loading services from configuration file', err);
+                winston.error(
+                    'Error loading services from configuration file: %s',
+                    JSON.stringify(config.getConfig().iota.types)
+                );
                 return callback(err);
             } else {
                 return callback(null);

--- a/test/docker-compose-dev.yml
+++ b/test/docker-compose-dev.yml
@@ -1,0 +1,29 @@
+version: "2"
+
+services:
+  mongodb:
+    ports:
+      - "27017:27017"
+    hostname: mongodb
+    image: mongo:3.2
+    stdin_open: true
+    tty: true
+
+  orion:
+    command: -dbhost mongodb -port 1026 -logLevel DEBUG
+    depends_on:
+      - mongodb
+    ports:
+      - "1026:1026"
+    hostname: orion
+    image: fiware/orion:latest
+    stdin_open: true
+    tty: true
+
+  mosquitto:
+    ports:
+      - "1883:1883"
+    hostname: mosquitto
+    image: eclipse-mosquitto:latest
+    stdin_open: true
+    tty: true

--- a/test/unit/groupProvisioningLoRaServerIo.js
+++ b/test/unit/groupProvisioningLoRaServerIo.js
@@ -63,14 +63,14 @@ describe('Configuration provisioning API: Provision groups', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 ),
                 async.apply(
                     utils.deleteEntityCB,
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device2:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device2'
                 ),
                 async.apply(iotagentLora.start, iotAgentConfig)
             ],
@@ -88,14 +88,14 @@ describe('Configuration provisioning API: Provision groups', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 ),
                 async.apply(
                     utils.deleteEntityCB,
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device2:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device2'
                 )
             ],
             done
@@ -135,7 +135,7 @@ describe('Configuration provisioning API: Provision groups', function() {
             }
         };
         var devId = 'lora_unprovisioned_device';
-        var cbEntityName = devId + ':' + options.json.services[0]['entity_type'];
+        var cbEntityName = options.json.services[0]['entity_type'] + ':' + devId;
         var optionsCB = {
             url: 'http://' + orionServer + '/v2/entities/' + cbEntityName,
             method: 'GET',
@@ -280,7 +280,7 @@ describe('Configuration provisioning API: Provision groups', function() {
         };
         it('Should keep on listening to devices from provisioned groups', function(done) {
             var devId = 'lora_unprovisioned_device2';
-            var cbEntityName = devId + ':' + options.json.services[0]['entity_type'];
+            var cbEntityName = options.json.services[0]['entity_type'] + ':' + devId;
             var optionsCB = {
                 url: 'http://' + orionServer + '/v2/entities/' + cbEntityName,
                 method: 'GET',

--- a/test/unit/groupProvisioningTTN.js
+++ b/test/unit/groupProvisioningTTN.js
@@ -64,14 +64,21 @@ describe('Configuration provisioning API: Provision groups', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 ),
                 async.apply(
                     utils.deleteEntityCB,
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device2:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device2'
+                ),
+                async.apply(
+                    utils.deleteEntityCB,
+                    iotAgentConfig.iota.contextBroker,
+                    service,
+                    subservice,
+                    'LoraDeviceGroup:lora_unprovisioned_device3'
                 ),
                 async.apply(iotagentLora.start, iotAgentConfig)
             ],
@@ -89,14 +96,21 @@ describe('Configuration provisioning API: Provision groups', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 ),
                 async.apply(
                     utils.deleteEntityCB,
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device2:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device2'
+                ),
+                async.apply(
+                    utils.deleteEntityCB,
+                    iotAgentConfig.iota.contextBroker,
+                    service,
+                    subservice,
+                    'LoraDeviceGroup:lora_unprovisioned_device3'
                 )
             ],
             done
@@ -136,7 +150,7 @@ describe('Configuration provisioning API: Provision groups', function() {
             }
         };
         var devId = 'lora_unprovisioned_device';
-        var cbEntityName = devId + ':' + options.json.services[0]['entity_type'];
+        var cbEntityName = options.json.services[0]['entity_type'] + ':' + devId;
         var optionsCB = {
             url: 'http://' + orionServer + '/v2/entities/' + cbEntityName,
             method: 'GET',
@@ -281,7 +295,7 @@ describe('Configuration provisioning API: Provision groups', function() {
             }
         };
         var devId = 'lora_unprovisioned_device';
-        var cbEntityName = devId + ':' + 'LoraDeviceGroup';
+        var cbEntityName = 'LoraDeviceGroup' + ':' + devId;
         var optionsCB = {
             url: 'http://' + orionServer + '/v2/entities/' + cbEntityName,
             method: 'GET',
@@ -358,7 +372,7 @@ describe('Configuration provisioning API: Provision groups', function() {
         };
         it('Should keep on listening to devices from provisioned groups', function(done) {
             var devId = 'lora_unprovisioned_device2';
-            var cbEntityName = devId + ':' + options.json.services[0]['entity_type'];
+            var cbEntityName = options.json.services[0]['entity_type'] + ':' + devId;
             var optionsCB = {
                 url: 'http://' + orionServer + '/v2/entities/' + cbEntityName,
                 method: 'GET',
@@ -410,7 +424,7 @@ describe('Configuration provisioning API: Provision groups', function() {
             }
         };
         var devId = 'lora_unprovisioned_device3';
-        var cbEntityName = devId + ':' + options.json.services[0]['entity_type'];
+        var cbEntityName = options.json.services[0]['entity_type'] + ':' + devId;
         var optionsCB = {
             url: 'http://' + orionServer + '/v2/entities/' + cbEntityName,
             method: 'GET',
@@ -537,7 +551,7 @@ describe('Configuration provisioning API: Provision groups', function() {
 
         it('Should unsuscribe from the corresponding MQTT topic', function(done) {
             var optionsCB = {
-                url: 'http://' + orionServer + '/v2/entities/LORA-N-005',
+                url: 'http://' + orionServer + '/v2/entities/lora_unprovisioned_device',
                 method: 'GET',
                 json: true,
                 headers: {
@@ -548,7 +562,10 @@ describe('Configuration provisioning API: Provision groups', function() {
             var attributesExample = utils.readExampleFile('./test/activeAttributes/cayenneLpp.json');
             var client = mqtt.connect('mqtt://' + testMosquittoHost);
             client.on('connect', function() {
-                client.publish('ari_ioe_app_demo1/devices/LORA-N-005/up', JSON.stringify(attributesExample));
+                client.publish(
+                    'ari_ioe_app_demo1/devices/lora_unprovisioned_device/up',
+                    JSON.stringify(attributesExample)
+                );
                 setTimeout(function() {
                     request(optionsCB, function(error, response, body) {
                         should.not.exist(error);

--- a/test/unit/staticProvisioning.js
+++ b/test/unit/staticProvisioning.js
@@ -63,7 +63,7 @@ describe('Static provisioning', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 )
             ],
             done
@@ -80,7 +80,7 @@ describe('Static provisioning', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 )
             ],
             done
@@ -161,7 +161,7 @@ describe('Static provisioning', function() {
 
             devId = 'lora_n_003';
             var type = 'Robot';
-            cbEntityName = devId + ':' + type;
+            cbEntityName = type + ':' + devId;
             optionsCB = {
                 url: 'http://' + orionServer + '/v2/entities/' + cbEntityName,
                 method: 'GET',
@@ -235,6 +235,49 @@ describe('Static provisioning', function() {
                 }
             };
             iotAgentConfig.iota.types['Robot2'] = sensorType;
+            sensorType = {
+                service: 'factory',
+                subservice: '/robots',
+                attributes: [
+                    {
+                        object_id: 'bp0',
+                        name: 'barometric_pressure_0',
+                        type: 'hpa'
+                    },
+                    {
+                        object_id: 'di3',
+                        name: 'digital_in_3',
+                        type: 'Number'
+                    },
+                    {
+                        object_id: 'do4',
+                        name: 'digital_out_4',
+                        type: 'Number'
+                    },
+                    {
+                        object_id: 'rh2',
+                        name: 'relative_humidity_2',
+                        type: 'Number'
+                    },
+                    {
+                        object_id: 't1',
+                        name: 'temperature_1',
+                        type: 'Number'
+                    }
+                ],
+                internalAttributes: {
+                    lorawan: {
+                        application_server: {
+                            host: 'localhost',
+                            provider: 'loraserver.io'
+                        },
+                        app_eui: '70B3D57ED000985F',
+                        application_id: '1',
+                        application_key: '9BE6B8EF16415B5F6ED4FBEAFE695C49'
+                    }
+                }
+            };
+            iotAgentConfig.iota.types['Robot'] = sensorType;
             iotagentLora.start(iotAgentConfig, function(error) {
                 should.exist(error);
                 return done();

--- a/test/unit/staticProvisioningLoRaServerIo.js
+++ b/test/unit/staticProvisioningLoRaServerIo.js
@@ -68,7 +68,7 @@ describe('Static provisioning', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 )
             ],
             done
@@ -85,7 +85,7 @@ describe('Static provisioning', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 )
             ],
             done
@@ -164,7 +164,7 @@ describe('Static provisioning', function() {
 
             devId = 'lora_n_003';
             var type = 'Robot';
-            cbEntityName = devId + ':' + type;
+            cbEntityName = type + ':' + devId;
             optionsCB = {
                 url: 'http://' + orionServer + '/v2/entities/' + cbEntityName,
                 method: 'GET',
@@ -239,8 +239,50 @@ describe('Static provisioning', function() {
                     }
                 }
             };
-
             newConf.iota.types['Robot2'] = sensorType;
+            sensorType = {
+                service: 'factory',
+                subservice: '/robots',
+                attributes: [
+                    {
+                        object_id: 'bp0',
+                        name: 'barometric_pressure_0',
+                        type: 'hpa'
+                    },
+                    {
+                        object_id: 'di3',
+                        name: 'digital_in_3',
+                        type: 'Number'
+                    },
+                    {
+                        object_id: 'do4',
+                        name: 'digital_out_4',
+                        type: 'Number'
+                    },
+                    {
+                        object_id: 'rh2',
+                        name: 'relative_humidity_2',
+                        type: 'Number'
+                    },
+                    {
+                        object_id: 't1',
+                        name: 'temperature_1',
+                        type: 'Number'
+                    }
+                ],
+                internalAttributes: {
+                    lorawan: {
+                        application_server: {
+                            host: 'localhost',
+                            provider: 'loraserver.io'
+                        },
+                        app_eui: '70B3D57ED000985F',
+                        application_id: '1',
+                        application_key: '9BE6B8EF16415B5F6ED4FBEAFE695C49'
+                    }
+                }
+            };
+            newConf.iota.types['Robot'] = sensorType;
             iotagentLora.start(newConf, function(error) {
                 should.exist(error);
                 return done();

--- a/test/unit/staticProvisioningTTN.js
+++ b/test/unit/staticProvisioningTTN.js
@@ -68,7 +68,7 @@ describe('Static provisioning', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 )
             ],
             done
@@ -85,7 +85,7 @@ describe('Static provisioning', function() {
                     iotAgentConfig.iota.contextBroker,
                     service,
                     subservice,
-                    'lora_unprovisioned_device:LoraDeviceGroup'
+                    'LoraDeviceGroup:lora_unprovisioned_device'
                 )
             ],
             done
@@ -166,7 +166,7 @@ describe('Static provisioning', function() {
 
             devId = 'lora_n_003';
             var type = 'Robot';
-            cbEntityName = devId + ':' + type;
+            cbEntityName = type + ':' + devId;
             optionsCB = {
                 url: 'http://' + orionServer + '/v2/entities/' + cbEntityName,
                 method: 'GET',
@@ -239,8 +239,52 @@ describe('Static provisioning', function() {
                     }
                 }
             };
-
             newConf.iota.types['Robot2'] = sensorType;
+            sensorType = {
+                service: 'factory',
+                subservice: '/robots',
+                attributes: [
+                    {
+                        object_id: 'bp0',
+                        name: 'barometric_pressure_0',
+                        type: 'hpa'
+                    },
+                    {
+                        object_id: 'di3',
+                        name: 'digital_in_3',
+                        type: 'Number'
+                    },
+                    {
+                        object_id: 'do4',
+                        name: 'digital_out_4',
+                        type: 'Number'
+                    },
+                    {
+                        object_id: 'rh2',
+                        name: 'relative_humidity_2',
+                        type: 'Number'
+                    },
+                    {
+                        object_id: 't1',
+                        name: 'temperature_1',
+                        type: 'Number'
+                    }
+                ],
+                internalAttributes: {
+                    lorawan: {
+                        application_server: {
+                            host: 'localhost',
+                            username: 'ari_ioe_app_demo1',
+                            password: 'ttn-account-v2.UitfM5cPazqW52_zbtgUS6wM5vp1MeLC9Yu-Cozjfp0',
+                            provider: 'TTN'
+                        },
+                        app_eui: '70B3D57ED000985F',
+                        application_id: '1',
+                        application_key: '9BE6B8EF16415B5F6ED4FBEAFE695C49'
+                    }
+                }
+            };
+            newConf.iota.types['Robot'] = sensorType;
             iotagentLora.start(newConf, function(error) {
                 should.exist(error);
                 return done();


### PR DESCRIPTION
This commit provide support for inheriting dynamically the configuration of a group for a device belonging to the group (#102)

* when a message is received, we search for its device group
* the device configuraiton is the merge of the device group and device configuration
* if a device does not exist when a message arrives, the self registration creates a device with empty configuration (in this way any change to the device group configuration will be carried over also to devices already self provisioned)

other fixes are introduced, for example, self provisioned devices are now mapped to `type:deviceId` entityId (following standard data model naming) rather than `deviceId:type`