### PR TITLE
Include docker image in config.json

### DIFF
--- a/.github/fiware/config.json
+++ b/.github/fiware/config.json
@@ -7,7 +7,7 @@
     "coveralls": "https://coveralls.io/github/Atos-Research-and-Innovation/IoTagent-LoRaWAN",
     "github": ["Atos-Research-and-Innovation/IoTagent-LoRaWAN"],
     "dockerregistry": ["hub.docker.com"],
-    "docker": [""],
+    "docker": ["fiware/iotagent-lorawan"],
     "email": "",
     "status": "incubating",
     "compose": "",


### PR DESCRIPTION
In order to allow automatic assessment of the produced image, the image should be included.