### PR TITLE
In the MQTT subscription, the text 'rx' is obsolete for ChirpStack. Changed to /event/up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.2.4](https://github.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN/compare/v1.2.3...v1.2.4) (2021-01-22)
+
+
+### Bug Fixes
+
+* loraserverioAppService.js : In the MQTT subscription, the text 'rx', which is obsolete for
+  ChirpStack since version 3.11.0 (11/18/2020), has been replaced by '/event/up', which is 
+  what ChirpStack is currently publishing. As a consequence, if (splittedMqttTopic.length !== 5)
+  also had to be changed from 5 to 6, since otherwise it gives a 'Bad format for a LoRaServer.io 
+  topic'.
+  Reference: https://www.chirpstack.io/application-server/integrations/mqtt/
+
+
 ## [1.2.3](https://github.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN/compare/v1.2.2...v1.2.3) (2019-06-13)
 
 

--- a/lib/applicationServers/loraserverioAppService.js
+++ b/lib/applicationServers/loraserverioAppService.js
@@ -94,7 +94,7 @@ class LoraserverIoService extends appService.AbstractAppService {
         winston.debug('Message', JSON.stringify(message));
 
         const splittedMqttTopic = mqttTopic.split('/');
-        if (splittedMqttTopic.length !== 5) {
+        if (splittedMqttTopic.length !== 6) {
             const errorMessage = 'Bad format for a LoRaServer.io topic';
             winston.error(errorMessage);
         } else {
@@ -140,7 +140,7 @@ class LoraserverIoService extends appService.AbstractAppService {
             throw new Error('Missing mandatory configuration attributes for lorawan:dev_eui');
         }
 
-        const mqttTopic = 'application/' + this.applicationId + '/device/' + devEUI.toLowerCase() + '/rx';
+        const mqttTopic = 'application/' + this.applicationId + '/device/' + devEUI.toLowerCase() + '/event/up';
         this.mqttClient.subscribeTopic(mqttTopic);
         winston.info('Mqtt topic subscribed:%s', mqttTopic);
     }
@@ -153,7 +153,7 @@ class LoraserverIoService extends appService.AbstractAppService {
      * @param      {<type>}  deviceObject  The device object
      */
     stopObservingDevice(devId, devEUI, deviceObject) {
-        const mqttTopic = 'application/' + this.applicationId + '/device/' + devEUI.toLowerCase() + '/rx';
+        const mqttTopic = 'application/' + this.applicationId + '/device/' + devEUI.toLowerCase() + '/event/up';
         this.mqttClient.unSubscribeTopic(mqttTopic);
         winston.info('Mqtt topic unsubscribed:%s', mqttTopic);
     }
@@ -162,7 +162,7 @@ class LoraserverIoService extends appService.AbstractAppService {
      * It observes all devices
      */
     observeAllDevices() {
-        const mqttTopic = 'application/' + this.applicationId + '/device/+/rx';
+        const mqttTopic = 'application/' + this.applicationId + '/device/+/event/up';
         this.mqttClient.subscribeTopic(mqttTopic);
         winston.info('Mqtt topic subscribed:%s', mqttTopic);
     }
@@ -171,7 +171,7 @@ class LoraserverIoService extends appService.AbstractAppService {
      * It stops observing all devices.
      */
     stopObserveAllDevices() {
-        const mqttTopic = 'application/' + this.applicationId + '/device/+/rx';
+        const mqttTopic = 'application/' + this.applicationId + '/device/+/event/up';
         this.mqttClient.unSubscribeTopic(mqttTopic);
         winston.info('Mqtt topic unsubscribed:%s', mqttTopic);
     }


### PR DESCRIPTION
When using ChirpStack (before loraserverio), in the MQTT subscription, the text 'rx' is obsolete since version 3.11.0 (11/18/2020), has been replaced by '/event/up', which is what ChirpStack is currently publishing. As a consequence, if (splittedMqttTopic.length !== 5) also had to be changed from 5 to 6, since otherwise it gives a 'Bad format for a LoRaServer.io topic'.

Reference: https://www.chirpstack.io/application-server/integrations/mqtt/