### PR TITLE
cla automated signature and pr template (#122)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+## Proposed changes
+
+Describe the big picture of your changes here to communicate to the
+maintainers why we should accept this pull request.
+If it fixes a bug or resolves a feature request, be sure to link to
+that issue.
+
+## Types of changes
+
+What types of changes does your code introduce to the project: _Put
+an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing
+      functionality to not work as expected)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after
+creating the PR. If you're unsure about any of them, don't hesitate to
+ask. We're here to help! This is simply a reminder of what we are going
+to look for before merging your code._
+
+- [ ] I have read the [CONTRIBUTING][contrib] doc
+- [ ] I have signed the [Contributor License Agreement][cla]
+- [ ] I have updated the [CHANGE LOG][log]
+- [ ] I have added tests that prove my fix is effective or that my
+      feature works
+- [ ] I have added necessary documentation (if appropriate)
+- [ ] Any dependent changes have been merged and published in
+      downstream modules
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion
+by explaining why you chose the solution you did and what alternatives
+you considered, etc...
+
+
+
+
+[cla]: https://raw.githubusercontent.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN/master/entity-cla_IoTAgent-Atos.pdf
+    "IoT Agent LoRaWAN Entity Contributor License Agreement"
+[contrib]: https://github.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN/blob/master/CONTRIBUTING.md
+    "Contributing to IoT Agent LoRaWAN"
+[log]: https://github.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN/blob/master/CHANGELOG.md
+    "IoT Agent LoRaWAN Change Log"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,7 +3,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened,closed,synchronize]
+    types: [opened, closed, synchronize]
 
 jobs:
   CLAssistant:
@@ -16,16 +16,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN_SECRET }}
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-cla-document: 'https://raw.githubusercontent.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN/master/entity-cla_IoTAgent-Atos.pdf' # e.g. a CLA or a DCO document
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-cla-document: "https://raw.githubusercontent.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN/master/entity-cla_IoTAgent-Atos.pdf" # e.g. a CLA or a DCO document
           # branch should not be protected
-          branch: 'cla-signature'
+          branch: "cla-signature"
           allowlist: user1,bot*
           # use-dco-flag: false #'Set this to true if you want to use a dco instead of a cla'
-
-         #below are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
           #remote-repository-name:  enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,34 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Alpha Release
+        uses: cla-assistant/github-action@v2.0.1-alpha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-cla-document: 'https://raw.githubusercontent.com/orchestracities/opa-authz/master/individual_cla.pdf' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'cla-signature'
+          allowlist: user1,bot*
+          # use-dco-flag: false #'Set this to true if you want to use a dco instead of a cla'
+
+         #below are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name:  enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-cla-document: 'https://raw.githubusercontent.com/orchestracities/opa-authz/master/individual_cla.pdf' # e.g. a CLA or a DCO document
+          path-to-cla-document: 'https://raw.githubusercontent.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN/master/entity-cla_IoTAgent-Atos.pdf' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'cla-signature'
           allowlist: user1,bot*


### PR DESCRIPTION
This PR implements #122 

Additionally:
- a new empty branch named `cla-signature` should be created
- in the branch a folder `signatures/version1/` should be created
- a secret named `PERSONAL_ACCESS_TOKEN` should be added to the repo including a PAT with scope `repo`
