### PR TITLE
add github test workflow (#125)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+# This action works with pull requests and pushes
+name: Test
+
+on:
+  ? pull_request
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [10, 12]
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker pull mongo:3.2
+      - run: docker run -d --net host -l mongodb mongo:3.2
+      - run: docker pull fiware/orion:latest
+      - run: docker run -d --net host -l orion fiware/orion:latest
+      - run: docker pull ansi/mosquitto
+      - run: docker run -d --net host -l mosquitto ansi/mosquitto
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install --also=dev
+      - env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: npm run test:coveralls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,5 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm install --also=dev
       - env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN_SECRET }}
         run: npm run test:coveralls

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "cbor-sync": "^1.0.3",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
     "mqtt": "^2.18.8",
     "request": "^2.88.0",
     "winston": "^3.1.0"


### PR DESCRIPTION
travis is not free anymore, which is probably the reason why functional tests are not more active on the repo.
this PR introduces functional tests using github actions.

to run correctly, a  secret `COVERALLS_REPO_TOKEN` needs to be configured including a token from https://coveralls.io/github/Atos-Research-and-Innovation/IoTagent-LoRaWAN?branch=master