### PR TITLE
fix failed build to due unauthenticated git protocol on port 9418

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "cbor-sync": "^1.0.3",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
     "mqtt": "^2.18.8",
     "request": "^2.88.0",
     "winston": "^3.1.0"


### PR DESCRIPTION
Github is not supporting anymore unauthenticated git protocol on port 9418:
https://github.blog/2021-09-01-improving-git-protocol-security-github/